### PR TITLE
Use more runloops to avoid scroll jitter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
             dependencies: ["LibSubsurface"]),
         .binaryTarget(
             name: "LibSubsurface",
-            url: "https://github.com/cdata/subconscious-swift-releases/releases/download/libsubsurface-v0.0.1/libsubsurface.zip",
-            checksum: "0e936fda337fc096cc77b382ec1d600b0b71b99b66e10f59c725ed92e6c91d39"),
+            url: "https://github.com/cdata/SwiftSubsurface/releases/download/v0.0.4/libsubsurface.zip",
+            checksum: "8c126e2d8eec82c5143ae88c99068797b0d8315a8f8118316bcc36057ae99a4a"),
         .testTarget(
             name: "SwiftSubsurfaceTests",
             dependencies: ["SwiftSubsurface"]),

--- a/Sources/SwiftSubsurface/SubsurfaceUIViewController.swift
+++ b/Sources/SwiftSubsurface/SubsurfaceUIViewController.swift
@@ -17,6 +17,7 @@ public class SubsurfaceUIViewController: UIViewController {
     
     lazy var displayLink: CADisplayLink = {
         let link = CADisplayLink.init(target: self, selector: #selector(enterFrame))
+        link.add(to: RunLoop.current, forMode: RunLoop.Mode.common)
         return link
     }()
     


### PR DESCRIPTION
Learning more about iOS every day here. We were experiencing halts in updates to the shader while scrolling. After reviewing this [Stack Overflow](https://stackoverflow.com/questions/12622800/why-does-uiscrollview-pause-my-cadisplaylink) I discovered that there are multiple run loops we can participate in when initializing the display link. This appears to have fixed the issue (but perhaps with some minor trade-offs for performance).